### PR TITLE
Adds initial v1 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ build/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# SQLite
+page_config.sqlite3
+page_config_test.sqlite3

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,9 @@ gem 'sinatra'
 gem 'sinatra-contrib'
 gem "sinatra-activerecord"
 
+gem 'roar'
+gem 'multi_json'
+
 gem 'thin'
 gem "sqlite3"
 gem 'racksh'

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,18 @@
+source 'https://rubygems.org'
+
+gem 'bundler'
+
+gem 'sinatra'
+gem 'sinatra-contrib'
+gem "sinatra-activerecord"
+
+gem 'thin'
+gem "sqlite3"
+gem 'racksh'
+gem "rake"
+
+group :test, :development do
+  gem 'rspec', '~> 3.2.0'
+  gem "rack-test"
+  gem 'database_cleaner'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,91 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (4.2.5.2)
+      activesupport (= 4.2.5.2)
+      builder (~> 3.1)
+    activerecord (4.2.5.2)
+      activemodel (= 4.2.5.2)
+      activesupport (= 4.2.5.2)
+      arel (~> 6.0)
+    activesupport (4.2.5.2)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    arel (6.0.3)
+    backports (3.6.8)
+    builder (3.2.2)
+    daemons (1.2.3)
+    database_cleaner (1.5.1)
+    diff-lcs (1.2.5)
+    eventmachine (1.0.9.1)
+    i18n (0.7.0)
+    json (1.8.3)
+    minitest (5.8.4)
+    multi_json (1.11.2)
+    rack (1.6.4)
+    rack-protection (1.5.3)
+      rack
+    rack-test (0.6.3)
+      rack (>= 1.0)
+    racksh (1.0.0)
+      rack (>= 1.0)
+      rack-test (>= 0.5)
+    rake (10.5.0)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.3)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-mocks (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-support (3.2.2)
+    sinatra (1.4.7)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    sinatra-activerecord (2.0.9)
+      activerecord (>= 3.2)
+      sinatra (~> 1.0)
+    sinatra-contrib (1.4.6)
+      backports (>= 2.0)
+      multi_json
+      rack-protection
+      rack-test
+      sinatra (~> 1.4.0)
+      tilt (>= 1.3, < 3)
+    sqlite3 (1.3.11)
+    thin (1.6.4)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (~> 1.0)
+    thread_safe (0.3.5)
+    tilt (2.0.2)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler
+  database_cleaner
+  rack-test
+  racksh
+  rake
+  rspec (~> 3.2.0)
+  sinatra
+  sinatra-activerecord
+  sinatra-contrib
+  sqlite3
+  thin
+
+BUNDLED WITH
+   1.10.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,10 @@ GEM
       rack (>= 1.0)
       rack-test (>= 0.5)
     rake (10.5.0)
+    representable (2.3.0)
+      uber (~> 0.0.7)
+    roar (1.0.4)
+      representable (>= 2.0.1, < 2.4.0)
     rspec (3.2.0)
       rspec-core (~> 3.2.0)
       rspec-expectations (~> 3.2.0)
@@ -70,6 +74,7 @@ GEM
     tilt (2.0.2)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    uber (0.0.15)
 
 PLATFORMS
   ruby
@@ -77,9 +82,11 @@ PLATFORMS
 DEPENDENCIES
   bundler
   database_cleaner
+  multi_json
   rack-test
   racksh
   rake
+  roar
   rspec (~> 3.2.0)
   sinatra
   sinatra-activerecord

--- a/README.md
+++ b/README.md
@@ -1,2 +1,174 @@
-# page_config
-Simple page configuration service.
+## Page Configuration Service
+
+A simple Sinatra based page configuration service. 
+
+It stores page configuration in local SQLite. Each stored page configuration consists of resource identifier and config part. It's possible to list, retrieve, create, update and delete individual page configuration. List of all configurations currently doesn't support pagination.
+
+### Getting started
+
+#### Install dependencies
+
+Run `bundler`:
+
+    $ bundle install
+
+#### Run Migrations
+
+    $ bundle exec rake db:migrate
+
+    and 
+
+    $ RACK_ENV=test bundle exec rake db:migrate
+
+#### Launch the API server
+
+    $ bundle exec rackup
+
+It'll start Thin server on default port 9292.
+
+### Tests
+
+    $ bundle exec rspec
+
+### IMPORTANT Assumptions
+
+This API assumes that new page configuration is provided as well formatted JSON. This configuration *must* include `id` field which value is used to identify resource. `id` must not contain spaces or non-alphanumeric character to ensure correct operation. `id` will be sanitised at the time of resource creation to remove all non-alphanumeric characters. Other than that, configuration JSON must include at least one configuration key with appropriate value. There is no limit of number or naming convention of other configuration keys.
+
+#### Example configuration
+
+    {
+      "id": "pageId",
+      "key1": "value1",
+      "key2": "value2",
+      ...
+      "keyN": "valueN"
+    }
+
+### Versioning
+
+This service uses API versioning. Currently all service endpoints are namespaced with `/v1`.
+
+### Usage
+
+#### GET /v1/pages 
+
+It will return collection of all stored page configuration. Currently this endpoint doesn't support pagination. 
+
+##### Example request
+
+    curl -H "Accept: application/json" http://localhost:9292/v1/pages
+
+##### Example response
+
+    {
+      "page": [
+        {
+          "id": "foo",
+          "config": {
+            "value": "some value"
+          }
+        },
+        {
+          "id": "bar",
+          "config": {
+            "key": "value"
+          }
+        }
+      ]
+    }
+
+##### Statuses
+
+  `200` - successful response.
+
+#### GET /v1/pages/:page_identifier
+
+It will return page configuration resource for given identifier.
+
+##### Example request
+
+    curl -H "Accept: application/json" http://localhost:9292/v1/pages/foo
+
+##### Example response
+
+    {
+      "page": {
+        "id": "foo",
+        "config": {
+          "value": "some value"
+        }
+      }
+    }
+
+##### Errors
+  `404` - returned when requested resource wasn't found.
+
+##### Statuses
+  `200` - successful response.
+
+#### POST /v1/pages
+
+It will create a new page configuration resource. 
+
+##### Example request
+
+    curl -H "Accept: application/json" \
+         -X POST \
+         -d '{"id": "foo","value": "I am foo"}' \ 
+         http://localhost:9292/v1/pages
+
+##### Example response
+
+  Response should contain `Location` header with newly created resource URI.
+
+##### Errors
+  `409` - returned when resource already exists.
+  `500` - returned when there was an issue when creating new resource.
+
+##### Statuses
+  `201` - returned when resource was succesfully created.
+
+
+#### PUT /v1/pages/:page_identifier
+
+It will update existing page configuration for specified resource.
+
+##### Example request
+
+    curl -H "Accept: application/json" \
+         -X PUT \
+         -d '{"id": "foo", "value": "Some new value"}' \ 
+         http://localhost:9292/v1/pages/foo
+
+##### Example response
+
+  No content.
+
+##### Errors
+  `404` - returned when requested resource doensn't exist.
+  `409` - returned when there was page identifier mismatch between updated resource and the one from new configuration ("id" field value).
+
+##### Statuses
+  `204` - No content is returned when operation was succesful.
+
+
+#### DELETE /v1/pages/:page_identifier
+
+It will delete existing page configuration for specified resource.
+
+##### Example request
+
+    curl -H "Accept: application/json" \
+         -X DELETE \
+         http://localhost:9292/v1/pages/foo
+
+##### Example response
+
+  No content.
+
+##### Errors
+  `404` - returned when requested resource doensn't exist.
+
+##### Statuses
+  `204` - No content is returned when operation was succesful.
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+require "sinatra/activerecord/rake"
+
+namespace :db do
+  task :load_config do
+    require "./api"
+  end
+end

--- a/api.rb
+++ b/api.rb
@@ -1,0 +1,39 @@
+require 'rubygems'
+require 'bundler'
+
+Bundler.require(:default)
+Bundler.require(Sinatra::Base.environment)
+
+require "sinatra/reloader" if development?
+require "sinatra/activerecord"
+
+module PageConfig
+  module Api 
+    class Base < Sinatra::Base
+      register Sinatra::ActiveRecordExtension
+
+      configure :development do
+        register Sinatra::Reloader
+      end
+
+      configure do
+        set :database, { 
+          adapter: "sqlite3", 
+          database: test? ? "page_config_test.sqlite3" : "page_config.sqlite3"
+        }
+        disable :method_override
+        disable :static
+      end
+
+      configure :development, :staging do
+        database.logger = Logger.new(STDOUT)
+        database.logger.level = Logger::INFO
+      end
+
+      not_found do
+        {error: 'Invalid URL.'}.to_json
+      end
+    end
+
+  end
+end

--- a/api.rb
+++ b/api.rb
@@ -12,6 +12,7 @@ $: << File.expand_path('../lib', __FILE__)
 
 require 'models'
 require 'representers'
+require 'routes'
 
 module PageConfig
   module Api 
@@ -41,5 +42,8 @@ module PageConfig
       end
     end
 
+    class V1 < Base
+      use Routes::V1::Pages
+    end
   end
 end

--- a/api.rb
+++ b/api.rb
@@ -7,6 +7,12 @@ Bundler.require(Sinatra::Base.environment)
 require "sinatra/reloader" if development?
 require "sinatra/activerecord"
 
+$: << File.expand_path('../', __FILE__)
+$: << File.expand_path('../lib', __FILE__)
+
+require 'models'
+require 'representers'
+
 module PageConfig
   module Api 
     class Base < Sinatra::Base

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,3 @@
+require "./api"
+
+map('/v1') { run PageConfig::Api::V1 }

--- a/db/migrate/20160229232633_create_pages.rb
+++ b/db/migrate/20160229232633_create_pages.rb
@@ -1,0 +1,12 @@
+class CreatePages < ActiveRecord::Migration
+  def change
+    create_table :pages do |t|
+      t.string :name, null: false
+      t.text :config, null: false
+      
+      t.timestamps null: false
+
+      t.index :name, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,25 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20160229232633) do
+
+  create_table "pages", force: :cascade do |t|
+    t.string   "name",       null: false
+    t.text     "config",     null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "pages", ["name"], name: "index_pages_on_name", unique: true
+
+end

--- a/lib/models.rb
+++ b/lib/models.rb
@@ -1,0 +1,1 @@
+require 'models/page'

--- a/lib/models/page.rb
+++ b/lib/models/page.rb
@@ -1,0 +1,14 @@
+class Page < ActiveRecord::Base
+  before_save :sanitize_name
+
+  validates :name, presence: true
+  validates :config, presence: true
+
+  serialize :config
+
+  private
+
+  def sanitize_name
+    self.name = self.name.downcase.gsub(/\W+/, '')
+  end
+end

--- a/lib/representers.rb
+++ b/lib/representers.rb
@@ -1,0 +1,1 @@
+require 'representers/page_representer'

--- a/lib/representers/page_representer.rb
+++ b/lib/representers/page_representer.rb
@@ -1,0 +1,9 @@
+require 'roar/json/json_api'
+
+module PageRepresenter
+  include Roar::JSON::JSONAPI
+  type :page
+
+  property :name, as: :id
+  property :config
+end

--- a/lib/routes.rb
+++ b/lib/routes.rb
@@ -1,0 +1,1 @@
+require 'routes/v1/pages'

--- a/lib/routes/v1/pages.rb
+++ b/lib/routes/v1/pages.rb
@@ -1,0 +1,30 @@
+module PageConfig
+  module Routes
+    module V1
+      class Pages < Sinatra::Application
+
+        before do
+          unless request.accept?('application/json')
+            halt 406, msg('Invalid Accept header.')
+          end
+        end
+
+        before do
+          content_type 'application/json'
+        end
+
+        get '/pages/?' do
+          pages = Page.order(updated_at: :desc)
+          PageRepresenter.for_collection.prepare(pages).to_json
+        end
+
+        private
+
+        def msg(message)
+          {msg: message}.to_json
+        end
+
+      end
+    end
+  end
+end

--- a/lib/routes/v1/pages.rb
+++ b/lib/routes/v1/pages.rb
@@ -13,9 +13,20 @@ module PageConfig
           content_type 'application/json'
         end
 
+        before do
+          page_identifier = request.path_info.split('/')[2]
+          pass unless page_identifier
+          @page = Page.find_by(name: page_identifier)
+          halt 404, msg("Resource doesn't exist.") if @page.nil?
+        end
+
         get '/pages/?' do
           pages = Page.order(updated_at: :desc)
           PageRepresenter.for_collection.prepare(pages).to_json
+        end
+
+        get '/pages/:name/?' do
+          PageRepresenter.prepare(@page).to_json
         end
 
         private

--- a/lib/routes/v1/pages.rb
+++ b/lib/routes/v1/pages.rb
@@ -51,6 +51,11 @@ module PageConfig
           status 204
         end
 
+        delete '/pages/:name' do
+          @page.delete
+          status 204
+        end
+
         private
 
         def msg(message)

--- a/lib/routes/v1/pages.rb
+++ b/lib/routes/v1/pages.rb
@@ -42,6 +42,15 @@ module PageConfig
           status 201
         end
 
+        put '/pages/:name/?' do
+          config = ::MultiJson.decode(request.body)
+          if params[:name] != config.delete('id')
+            halt 409, msg("Page identifier mismatch. Resource ID and configuration page ID are different.")
+          end
+          @page.update(config: config)
+          status 204
+        end
+
         private
 
         def msg(message)

--- a/lib/routes/v1/pages.rb
+++ b/lib/routes/v1/pages.rb
@@ -29,6 +29,19 @@ module PageConfig
           PageRepresenter.prepare(@page).to_json
         end
 
+        post '/pages/?' do
+          config = ::MultiJson.decode(request.body)
+          begin
+            page_config = Page.create!(name: config.delete('id'), config: config)
+          rescue ActiveRecord::RecordNotUnique => e
+            halt 409, msg("Page configuration already exist.")
+          rescue => e
+            halt 500, msg("Resource could't be created.")
+          end
+          response.headers['Location'] = "/pages/#{page_config.name}"
+          status 201
+        end
+
         private
 
         def msg(message)

--- a/spec/lib/models/page_spec.rb
+++ b/spec/lib/models/page_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+RSpec.describe Page do
+
+  describe 'callbacks' do
+
+    describe 'sanitize_name' do
+      let(:name) { '12 hello-world %' }
+
+      it 'sanitizes name by downcasing and removing all non-alphanumeric characters' do
+        expect(Page.create(name: name, config: {key1: 'val1'}).name).to eq '12helloworld'
+      end
+    end
+
+  end
+
+  describe 'validations' do
+
+    describe 'name' do
+      it 'should be present' do
+        p = Page.new(config: {key1: 'val1'})
+        expect(p).to_not be_valid
+        expect(p.errors[:name]).to include("can't be blank")
+
+        p.name = 'foo'
+        expect(p).to be_valid
+      end
+    end
+
+    describe 'config' do
+      it 'should be present' do
+        p = Page.new(name: 'foo')
+        expect(p).to_not be_valid
+        expect(p.errors[:config]).to include("can't be blank")
+
+        p.config = {key1: 'val1'}
+        expect(p).to be_valid
+      end
+    end
+
+  end
+end

--- a/spec/lib/representers/page_representer_spec.rb
+++ b/spec/lib/representers/page_representer_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+RSpec.describe PageRepresenter do
+  subject(:presenter) { PageRepresenter }
+
+  before do
+    @p1 = Page.new(name: 'pageid1', config: {key1: 'val1'})
+    @p2 = Page.new(name: 'pageid2', config: {key2: 'val2'})
+  end
+
+  describe '.prepare' do
+    let(:expected_output) do
+      {
+        page: {
+          id: 'pageid1',
+          config: {
+            key1: 'val1'
+          }
+        }
+      }.to_json
+    end
+
+    it 'presents a single resource' do
+      expect(presenter.prepare(@p1).to_json).to eq expected_output
+    end
+  end
+
+  describe '.for_collection' do
+    describe '.prepare' do
+      let(:expected_output) do
+        {
+          page: [
+            {
+              id: 'pageid1',
+              config: {
+                key1: 'val1'
+              }
+            },
+            {
+              id: 'pageid2',
+              config: {
+                key2: 'val2'
+              }
+            } 
+          ]     
+        }.to_json
+      end
+
+      it 'presents collection of resources' do      
+        expect(presenter.for_collection.prepare([@p1, @p2]).to_json).to eq expected_output
+      end
+    end
+  end
+
+end

--- a/spec/lib/routes/v1/pages_spec.rb
+++ b/spec/lib/routes/v1/pages_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+RSpec.describe PageConfig::Api::V1 do
+
+  describe 'before filters' do
+
+    context "when client doesn't specify correct Accept header" do
+      it "returns 406 with appropriate message" do
+        get "/pages", {}, {"HTTP_ACCEPT"=>"text/plain"}
+
+        expect(last_response.body).to eq({msg: "Invalid Accept header."}.to_json)
+        expect(last_response.status).to eq 406
+      end
+    end
+
+    context "with correct Accept header" do
+      it "allows to call underlying actions" do
+        get "/pages", {}, {"HTTP_ACCEPT"=>"application/json"}
+
+        expect(last_response.status).to eq 200
+      end
+    end
+
+    it "sets correct content_type response header" do
+      get "/pages"
+
+      expect(last_response.header["Content-Type"]).to eq "application/json"
+      expect(last_response.status).to eq 200
+    end
+
+  end
+
+  describe "GET /pages" do
+
+    context "when there is no configuration stored" do
+      it "returns an empty list all configs" do
+        get "/pages"
+
+        expect(last_response.body).to eq({page: []}.to_json)
+        expect(last_response.status).to eq 200
+      end
+    end
+
+    context "when there is at least 1 page configuration" do
+      before do
+        Page.create(name: "foo1", config: {key1: "val1"})
+        Page.create(name: "foo2", config: {key2: "val2"})
+      end
+
+      let(:expected_output) do
+        {
+          page: [
+            {id: "foo2", config: {key2: "val2"}},
+            {id: "foo1", config: {key1: "val1"}}
+          ]
+        }.to_json
+      end
+
+      it "returns all stored page configs" do
+        get "/pages"
+
+        expect(last_response.body).to eq expected_output
+        expect(last_response.status).to eq 200
+      end
+    end
+  end
+
+end

--- a/spec/lib/routes/v1/pages_spec.rb
+++ b/spec/lib/routes/v1/pages_spec.rb
@@ -90,6 +90,14 @@ RSpec.describe PageConfig::Api::V1 do
         expect(last_response.body).to eq expected_output
         expect(last_response.status).to eq 200
       end
+
+      it "sets ETag, Last-Modified and Cache-Control headers" do
+        get "/pages"
+
+        expect(last_response.header["Cache-Control"]).to eq "public, must-revalidate"
+        expect(last_response.header["Last-Modified"]).to_not be_empty
+        expect(last_response.header["ETag"]).to_not be_empty
+      end
     end
   end
 
@@ -126,6 +134,15 @@ RSpec.describe PageConfig::Api::V1 do
         expect(last_response.body).to eq expected_output
         expect(last_response.status).to eq 200
       end
+
+      it "sets ETag, Last-Modified and Cache-Control headers" do
+        get "/pages/foo"
+
+        expect(last_response.header["Cache-Control"]).to eq "public, must-revalidate"
+        expect(last_response.header["Last-Modified"]).to_not be_empty
+        expect(last_response.header["ETag"]).to_not be_empty
+      end
+
     end
 
   end

--- a/spec/lib/routes/v1/pages_spec.rb
+++ b/spec/lib/routes/v1/pages_spec.rb
@@ -170,4 +170,45 @@ RSpec.describe PageConfig::Api::V1 do
 
   end
 
+  describe 'PUT /pages/foo' do
+    let(:page) { Page.create(name: 'foo', config: {key0: 'val0'}) }
+
+    context "when there is a mismatch between update resource ID and page ID in new configuration" do
+      let(:new_config) do
+        {
+          id: 'bar',
+          val1: 'key1'
+        }.to_json
+      end
+
+      it "raturns 409 with appropriate message" do
+        allow(Page).to receive(:find_by).with(name: 'foo') { page }
+
+        put '/pages/foo', new_config
+
+        expect(last_response.body).to eq({msg: "Page identifier mismatch. Resource ID and configuration page ID are different."}.to_json)
+        expect(last_response.status).to eq 409
+      end
+    end
+
+    context "for valid new configuration" do
+      let(:new_config) do
+        {
+          id: 'foo',
+          val1: 'key1'
+        }.to_json
+      end
+
+      it "updates existing config and returns 204" do
+        allow(Page).to receive(:find_by).with(name: 'foo') { page }
+        expect(page).to receive(:update).with(config: {'val1' => 'key1'})
+
+        put '/pages/foo', new_config
+
+        expect(last_response.status).to eq 204
+      end
+    end
+
+  end
+
 end

--- a/spec/lib/routes/v1/pages_spec.rb
+++ b/spec/lib/routes/v1/pages_spec.rb
@@ -130,4 +130,44 @@ RSpec.describe PageConfig::Api::V1 do
 
   end
 
+  describe "POST /pages" do
+    let(:configuration) do
+      {id: 'pageid', val1: 'val1', val2: 'val2'}.to_json
+    end
+
+    context "when configuration already exist for given page" do
+      before do
+        post "/pages", configuration
+      end
+
+      it "returns 409 with appropriate message" do
+        post "/pages", configuration
+
+        expect(last_response.body).to eq({msg: "Page configuration already exist."}.to_json)
+        expect(last_response.status).to eq 409
+      end
+    end
+
+    context "when there was an exception during configuration creation" do
+      it "return 500 with appropriate message" do
+        allow(Page).to receive(:create!).and_raise(ActiveRecord::StatementInvalid, "error desc")
+
+        post "/pages", {key1: 'val1'}.to_json
+
+        expect(last_response.body).to eq({msg: "Resource could't be created."}.to_json)
+        expect(last_response.status).to eq 500
+      end
+    end
+
+    context "when there was no errors" do
+      it "creates a new configuration and sets Location header" do
+        post "/pages", configuration
+
+        expect(last_response.header["Location"]).to eq "/pages/pageid"
+        expect(last_response.status).to eq 201
+      end
+    end
+
+  end
+
 end

--- a/spec/lib/routes/v1/pages_spec.rb
+++ b/spec/lib/routes/v1/pages_spec.rb
@@ -211,4 +211,17 @@ RSpec.describe PageConfig::Api::V1 do
 
   end
 
+  describe 'DELETE /pages/foo' do
+    let(:page) { Page.create(name: 'foo', config: {key0: 'val0'}) }
+    
+    it "removes existing page configuration" do
+      allow(Page).to receive(:find_by).with(name: 'foo') { page }
+      expect(page).to receive(:delete)
+
+      delete '/pages/foo'
+
+      expect(last_response.status).to eq 204
+    end
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,44 @@
+ENV['RACK_ENV'] = 'test'
+
+require "./api"
+
+RSpec.configure do |config|
+  include Rack::Test::Methods
+  def app() described_class end
+
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.before(:suite) do
+    DatabaseCleaner.clean_with :truncation  # clean DB of any leftover data
+    DatabaseCleaner.strategy = :transaction # rollback transactions between each test
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
+
+  config.warnings = true
+
+  if config.files_to_run.one?
+    config.default_formatter = 'doc'
+  end
+
+  config.profile_examples = 10
+
+  config.order = :random
+
+  Kernel.srand config.seed
+end


### PR DESCRIPTION
This PR adds initial v1 version of API. 

For installation and usage guides please take a look at [README](https://github.com/marcinc/page_config/tree/v1#page-configuration-service).

There is important assumption regarding configuration JSON and its structure. Please read more [here](https://github.com/marcinc/page_config/tree/v1#important-assumptions).
